### PR TITLE
Implement first-time user confirmations

### DIFF
--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -61,6 +61,7 @@ export default async function Login({
   const signUp = async (formData: FormData) => {
     "use server"
 
+    const origin = headers().get("origin")
     const email = formData.get("email") as string
     const password = formData.get("password") as string
 
@@ -105,7 +106,7 @@ export default async function Login({
       password,
       options: {
         // USE IF YOU WANT TO SEND EMAIL VERIFICATION, ALSO CHANGE TOML FILE
-        // emailRedirectTo: `${origin}/auth/callback`
+        emailRedirectTo: `${origin}/auth/callback`
       }
     })
 
@@ -114,10 +115,10 @@ export default async function Login({
       return redirect(`/login?message=${error.message}`)
     }
 
-    return redirect("/setup")
+    // return redirect("/setup")
 
     // USE IF YOU WANT TO SEND EMAIL VERIFICATION, ALSO CHANGE TOML FILE
-    // return redirect("/login?message=Check email to continue sign in process")
+    return redirect("/login?message=Check email to continue sign in process")
   }
 
   const handleResetPassword = async (formData: FormData) => {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -74,7 +74,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 
 # Uncomment to customize email template
 # [auth.email.template.invite]


### PR DESCRIPTION
I successfully connected HackerGPT 2.0 to our SMTP server, enabling smooth handling of email confirmations for new users and password resets. The SMTP is connected to [noreply@hackerai.co](mailto:noreply@hackerai.co). Everything appears to be functioning well based on my tests. @momonja3, please review the code and functionality.

![Screenshot_20240203_182117](https://github.com/Hacker-GPT/hackergpt-2v/assets/144740362/d7446843-3dc2-4b56-bdbf-1af790760e3a)
